### PR TITLE
optimize discrete_fourier_transform memory usage

### DIFF
--- a/discrete_fourier_transform.go
+++ b/discrete_fourier_transform.go
@@ -35,33 +35,28 @@ func DiscreteFourierTransformTest(bits []bool) (float64, float64) {
 		panic("please provide test bits")
 	}
 
-	// Step 1
-	r := make([]float64, n)
+	// Step 1, 2
+	N := ceilPow2(n)
+	rr := make([]complex128, N)
 	for i := 0; i < n; i++ {
 		if bits[i] {
-			r[i] = 1.0
+			rr[i] = complex(1.0, 0)
 		} else {
-			r[i] = -1.0
+			rr[i] = complex(-1.0, 0)
 		}
 	}
 
-	// Step 2
-	r = pow2DoubleArr(r)
-	rr := make([]complex128, len(r))
-	for i := range r {
-		rr[i] = complex(r[i], 0)
-	}
-
 	// 傅里叶变换
-	f, err := ttf.New(len(r))
+	var result []complex128
+	f, err := ttf.New(N)
 	if err != nil {
 		panic(err)
 	}
-	result := f.Transform(rr)
+	result = f.Transform(rr)
 
 	// Step 4
 	T := math.Sqrt(2.995732274 * float64(n))
-	
+
 	// Step 5
 	N_0 := 0.95 * float64(n) / 2
 

--- a/discrete_fourier_transform.go
+++ b/discrete_fourier_transform.go
@@ -47,12 +47,11 @@ func DiscreteFourierTransformTest(bits []bool) (float64, float64) {
 	}
 
 	// 傅里叶变换
-	var result []complex128
 	f, err := ttf.New(N)
 	if err != nil {
 		panic(err)
 	}
-	result = f.Transform(rr)
+	f.Transform(rr)
 
 	// Step 4
 	T := math.Sqrt(2.995732274 * float64(n))
@@ -63,7 +62,7 @@ func DiscreteFourierTransformTest(bits []bool) (float64, float64) {
 	// Step 6
 	var N_1 int = 0
 	for i := 0; i < n/2-1; i++ {
-		if cmplx.Abs(result[i]) < T {
+		if cmplx.Abs(rr[i]) < T {
 			N_1++
 		}
 	}

--- a/discrete_fourier_transform_test.go
+++ b/discrete_fourier_transform_test.go
@@ -12,3 +12,12 @@ func TestDiscreteFourierTransformTestSample(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+func BenchmarkDiscreteFourierTransformTest(b *testing.B) {
+	bits := getEConstantBits()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = DiscreteFourierTransformTest(bits)
+	}
+}

--- a/discrete_fourier_transform_test.go
+++ b/discrete_fourier_transform_test.go
@@ -14,10 +14,8 @@ func TestDiscreteFourierTransformTestSample(t *testing.T) {
 }
 
 func BenchmarkDiscreteFourierTransformTest(b *testing.B) {
-	bits := getEConstantBits()
+	bits := make([]bool, 100000000)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _ = DiscreteFourierTransformTest(bits)
-	}
+	_, _ = DiscreteFourierTransformTest(bits)
 }

--- a/utils.go
+++ b/utils.go
@@ -287,6 +287,16 @@ func pow2DoubleArr(data []float64) []float64 {
 	return newData
 }
 
+func ceilPow2(N int) int {
+	i := 2
+	for {
+		if i >= N {
+			return i
+		}
+		i <<= 1
+	}
+}
+
 // B2bit 字节 转换为 bool数组
 func B2bit(b byte) []bool {
 	return []bool{

--- a/utils_test.go
+++ b/utils_test.go
@@ -31,6 +31,32 @@ func TestB2bit(t *testing.T) {
 	}
 }
 
+func TestCeilPow2(t *testing.T) {
+	tests := []struct {
+		name string
+		N    int
+		want int
+	}{
+		{"1", 1, 2},
+		{"2", 2, 2},
+		{"3", 3, 4},
+		{"4", 4, 4},
+		{"5", 5, 8},
+		{"6", 6, 8},
+		{"7", 7, 8},
+		{"8", 8, 8},
+		{"9", 9, 16},
+		{"10", 10, 16},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ceilPow2(tt.N); got != tt.want {
+				t.Errorf("ceilPow2() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestB2Byte(t *testing.T) {
 
 	tests := []struct {


### PR DESCRIPTION
目前100000000bits跑一下资源占用是这个情况：

    pkg: github.com/Trisia/randomness
    cpu: Intel(R) Core(TM) i5-9500 CPU @ 3.00GHz
    BenchmarkDiscreteFourierTransformTest-6   	       1	103390903100 ns/op	7516194664 B/op	      10 allocs/op