### PR TITLE
一些优化

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,13 +13,16 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goVer: ['1.18', '1.21']        
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.18
+        go-version: ${{ matrix.goVer }}
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -1,0 +1,28 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -14,12 +14,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.18
+        go-version: 1.21
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -1,7 +1,7 @@
 # This workflow will build a golang project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
-name: Go
+name: Slow test
 
 on:
   push:

--- a/approximate_entropy.go
+++ b/approximate_entropy.go
@@ -35,83 +35,42 @@ func ApproximateEntropyTestBytes(data []byte, m int) (float64, float64) {
 // m: m长度
 func ApproximateEntropyProto(bits []bool, m int) (float64, float64) {
 	n := len(bits)
+	numOfBlocks := float64(n)
 	if n == 0 {
 		panic("please provide test bits")
 	}
-	bits2 := bits
 	var pattern []int
-	var mask int
-	var tmp int = 0
-	var Cjm float64
-	var phim, phim1 float64 = 0, 0
-	var ApEn float64
+	var ApEn [2]float64
 	var V float64
 	var P float64
+	r := 0
 
-	// round1
-	for i := 0; i < m-1; i++ {
-		bits = append(bits, bits[i])
-	}
-	pattern = make([]int, 1<<m)
-	mask = (1 << m) - 1
-
-	var b bool
-	for i := 0; i < m-1; i++ {
-		tmp <<= 1
-		b, bits = bits[0], bits[1:]
-		if b {
-			tmp++
+	for blockSize := m; blockSize <= m+1; blockSize++ {
+		powLen := 1<<blockSize
+		pattern = make([]int, powLen)
+		for i := 0; i < n; i++ {
+			k := 1
+			for j := 0; j < blockSize; j++ {
+				k <<= 1
+				if bits[(i+j)%n] {
+					k++
+				}
+			}
+			pattern[k-powLen]++
 		}
-	}
-
-	for i := 0; i < n; i++ {
-		tmp <<= 1
-		b, bits = bits[0], bits[1:]
-		if b {
-			tmp++
+		sum := float64(0.0)
+		for i := 0; i < powLen; i++ {
+			if pattern[i] > 0 {
+				sum += float64(pattern[i]) * math.Log(float64(pattern[i])/numOfBlocks)
+			}
 		}
-		pattern[tmp&mask]++
+		sum /= numOfBlocks
+		ApEn[r] = sum
+		r++
 	}
-
-	for i := 0; i < (1 << m); i++ {
-		Cjm = float64(pattern[i]) / float64(n)
-		phim += Cjm * math.Log(Cjm)
-	}
-
-	// round2
-	bits = bits2
-	m++
-	for i := 0; i < m-1; i++ {
-		bits = append(bits, bits[i])
-	}
-	pattern = make([]int, 1<<m)
-	mask = (1 << m) - 1
-
-	for i := 0; i < m-1; i++ {
-		tmp <<= 1
-		b, bits = bits[0], bits[1:]
-		if b {
-			tmp++
-		}
-	}
-	for i := 0; i < n; i++ {
-		tmp <<= 1
-		b, bits = bits[0], bits[1:]
-		if b {
-			tmp++
-		}
-		pattern[tmp&mask]++
-	}
-
-	for i := 0; i < (1 << m); i++ {
-		Cjm = float64(pattern[i]) / float64(n)
-		phim1 += Cjm * math.Log(Cjm)
-	}
-	// --
-	m--
-	ApEn = phim - phim1
-	V = 2.0 * float64(n) * (math.Log(2) - ApEn)
-	_2m := 1 << m
-	P = igamc(float64(_2m)/2.0, V/2.0)
+	apen := ApEn[0] - ApEn[1]
+	V = 2.0 * numOfBlocks * (math.Log(2) - apen)
+	_2mMinus1 := 1 << (m - 1)
+	P = igamc(float64(_2mMinus1), V/2.0)
 	return P, P
 }

--- a/autocorrelation.go
+++ b/autocorrelation.go
@@ -50,8 +50,8 @@ func AutocorrelationProto(bits []bool, d int) (float64, float64) {
 		}
 	}
 
-	V = 2.0 * (float64(Ad) - (float64(n-d) / 2.0)) / math.Sqrt(float64(n-d))
-	P := math.Erfc(math.Abs(V) / math.Sqrt(2))
-	Q := math.Erfc(V/math.Sqrt(2)) / 2
+	V = 2.0 * (float64(Ad) - (float64(n-d) / 2.0)) / math.Sqrt(2*float64(n-d)) // 提前对V除以2的平方根，避免求P Q时再求解
+	P := math.Erfc(math.Abs(V))
+	Q := math.Erfc(V) / 2
 	return P, Q
 }

--- a/binary_derivative.go
+++ b/binary_derivative.go
@@ -61,13 +61,13 @@ func BinaryDerivativeProto(bits []bool, k int) (float64, float64) {
 			S--
 		}
 	}
-	// Step 4
-	V = float64(S) / math.Sqrt(float64(n-k))
+	// Step 4, 提前对V除以2的平方根，避免求P Q时再求解
+	V = float64(S) / math.Sqrt(2*float64(n-k))
 
 	// Step 5
-	P := math.Erfc(math.Abs(V) / math.Sqrt(2))
+	P := math.Erfc(math.Abs(V))
 
 	// Step 6
-	Q := math.Erfc(V/math.Sqrt(2)) / 2
+	Q := math.Erfc(V) / 2
 	return P, Q
 }

--- a/cumulative.go
+++ b/cumulative.go
@@ -56,12 +56,12 @@ func CumulativeTest(bits []bool, forward bool) (float64, float64) {
 		Z = max(Z, abs(S))
 	}
 
-	_n := float64(n)
+	sqrtN := math.Sqrt(float64(n)) // 提前求平方根，避免下面多次求平方根
 	for i := ((-n / Z) + 1) / 4; i <= ((n/Z)-1)/4; i++ {
-		P -= normal_CDF(float64((4*i+1)*Z)/math.Sqrt(_n)) - normal_CDF(float64((4*i-1)*Z)/math.Sqrt(_n))
+		P -= normal_CDF(float64((4*i+1)*Z)/sqrtN) - normal_CDF(float64((4*i-1)*Z)/sqrtN)
 	}
 	for i := ((-n / Z) - 3) / 4; i <= ((n/Z)-1)/4; i++ {
-		P += normal_CDF(float64((4*i+3)*Z)/math.Sqrt(_n)) - normal_CDF(float64((4*i+1)*Z)/math.Sqrt(_n))
+		P += normal_CDF(float64((4*i+3)*Z)/sqrtN) - normal_CDF(float64((4*i+1)*Z)/sqrtN)
 	}
 	return P, P
 }

--- a/discrete_fourier_transform.go
+++ b/discrete_fourier_transform.go
@@ -68,9 +68,9 @@ func DiscreteFourierTransformTest(bits []bool) (float64, float64) {
 	}
 
 	// Step 7
-	V := (float64(N_1) - N_0) / math.Sqrt(0.95*0.05*float64(n)/3.8)
-	P := math.Erfc(math.Abs(V) / math.Sqrt(2.0))
-	Q := math.Erfc(V/math.Sqrt(2.0)) / 2
+	V := (float64(N_1) - N_0) / math.Sqrt(0.95*0.05*float64(2.0*n)/3.8)
+	P := math.Erfc(math.Abs(V))
+	Q := math.Erfc(V) / 2
 
 	return P, Q
 }

--- a/discrete_fourier_transform.go
+++ b/discrete_fourier_transform.go
@@ -67,7 +67,7 @@ func DiscreteFourierTransformTest(bits []bool) (float64, float64) {
 		}
 	}
 
-	// Step 7
+	// Step 7，最后V除math.Sqrt(2)，放到这里提前处理，减少math.Sqrt的调用。
 	V := (float64(N_1) - N_0) / math.Sqrt(0.95*0.05*float64(2.0*n)/3.8)
 	P := math.Erfc(math.Abs(V))
 	Q := math.Erfc(V) / 2

--- a/frequency_within_block.go
+++ b/frequency_within_block.go
@@ -69,7 +69,7 @@ func FrequencyWithinBlockProto(bits []bool, m int) (float64, float64) {
 		Pi = Pi - 0.5
 		V += Pi * Pi
 	}
-	V *= 4.0 * float64(m)
-	P = igamc(float64(N)/2.0, V/2.0)
+	V *= 2.0 * float64(m)
+	P = igamc(float64(N)/2.0, V)
 	return P, P
 }

--- a/frequency_within_block.go
+++ b/frequency_within_block.go
@@ -66,7 +66,8 @@ func FrequencyWithinBlockProto(bits []bool, m int) (float64, float64) {
 			}
 		}
 		Pi = Pi / float64(m)
-		V += (Pi - 0.5) * (Pi - 0.5)
+		Pi = Pi - 0.5
+		V += Pi * Pi
 	}
 	V *= 4.0 * float64(m)
 	P = igamc(float64(N)/2.0, V/2.0)

--- a/frequency_within_block.go
+++ b/frequency_within_block.go
@@ -69,7 +69,7 @@ func FrequencyWithinBlockProto(bits []bool, m int) (float64, float64) {
 		Pi = Pi - 0.5
 		V += Pi * Pi
 	}
-	V *= 2.0 * float64(m)
+	V *= 2.0 * float64(m) // 这一步本来V要乘以4，现在改为2，免得后一步再除以2。
 	P = igamc(float64(N)/2.0, V)
 	return P, P
 }

--- a/maurers_universal.go
+++ b/maurers_universal.go
@@ -82,9 +82,9 @@ func MaurerUniversalTest(bits []bool) (float64, float64) {
 	}
 
 	sigma = math.Sqrt(variance[L]/float64(K)) * mutFactorC(L, K)
-	V = (sum/float64(K) - expected_value[L]) / sigma
-	P = math.Erfc(math.Abs(V) / math.Sqrt(2.0))
-	q := math.Erfc(V/math.Sqrt(2.0)) / 2
+	V = (sum/float64(K) - expected_value[L]) / (sigma*math.Sqrt(2.0)) // 避免求p q时V再除以math.Sqrt(2.0)
+	P = math.Erfc(math.Abs(V))
+	q := math.Erfc(V) / 2
 
 	return P, q
 }

--- a/mono_bit_frequency.go
+++ b/mono_bit_frequency.go
@@ -22,6 +22,7 @@ func MonoBitFrequency(data []byte) *TestResult {
 }
 
 // MonoBitFrequencyTestBytes 单比特频数检测
+// 这里直接对字节直接处理，避免字节切片到位切片的转换，同时提高效率。
 func MonoBitFrequencyTestBytes(data []byte) (float64, float64) {
 	if len(data) == 0 {
 		panic("please provide test bits")
@@ -31,9 +32,9 @@ func MonoBitFrequencyTestBytes(data []byte) (float64, float64) {
 	var V, P, Q float64
 
 	for _, b := range data {
-		S += bits.OnesCount8(b)<<1 - 8
+		S += bits.OnesCount8(b)<<1 - 8  // S += (bits.OnesCount8(b) - (8 - bits.OnesCount8(b)))
 	}
-	V = float64(S) / math.Sqrt(float64(2*n))
+	V = float64(S) / math.Sqrt(float64(2*n)) // 除math.Sqrt(2)，放到这里提前处理(n->2*n)，减少math.Sqrt的调用。
 	P = math.Erfc(math.Abs(V))
 	Q = math.Erfc(V) / 2
 	return P, Q
@@ -55,7 +56,7 @@ func MonoBitFrequencyTest(bits []bool) (float64, float64) {
 			S--
 		}
 	}
-	V = float64(S) / math.Sqrt(float64(2*n))
+	V = float64(S) / math.Sqrt(float64(2*n)) // 除math.Sqrt(2)，放到这里提前处理(n->2*n)，减少math.Sqrt的调用。
 	P = math.Erfc(math.Abs(V))
 	Q = math.Erfc(V) / 2
 	return P, Q

--- a/mono_bit_frequency.go
+++ b/mono_bit_frequency.go
@@ -12,6 +12,7 @@ package randomness
 
 import (
 	"math"
+	"math/bits"
 )
 
 // MonoBitFrequency 单比特频数检测
@@ -22,7 +23,20 @@ func MonoBitFrequency(data []byte) *TestResult {
 
 // MonoBitFrequencyTestBytes 单比特频数检测
 func MonoBitFrequencyTestBytes(data []byte) (float64, float64) {
-	return MonoBitFrequencyTest(B2bitArr(data))
+	if len(data) == 0 {
+		panic("please provide test bits")
+	}
+	n := len(data) * 8
+	S := 0
+	var V, P, Q float64
+
+	for _, b := range data {
+		S += bits.OnesCount8(b)<<1 - 8
+	}
+	V = float64(S) / math.Sqrt(float64(n))
+	P = math.Erfc(math.Abs(V) / math.Sqrt(2))
+	Q = math.Erfc(V/math.Sqrt(2)) / 2
+	return P, Q
 }
 
 // MonoBitFrequencyTest 单比特频数检测

--- a/mono_bit_frequency.go
+++ b/mono_bit_frequency.go
@@ -33,9 +33,9 @@ func MonoBitFrequencyTestBytes(data []byte) (float64, float64) {
 	for _, b := range data {
 		S += bits.OnesCount8(b)<<1 - 8
 	}
-	V = float64(S) / math.Sqrt(float64(n))
-	P = math.Erfc(math.Abs(V) / math.Sqrt(2))
-	Q = math.Erfc(V/math.Sqrt(2)) / 2
+	V = float64(S) / math.Sqrt(float64(2*n))
+	P = math.Erfc(math.Abs(V))
+	Q = math.Erfc(V) / 2
 	return P, Q
 }
 
@@ -55,8 +55,8 @@ func MonoBitFrequencyTest(bits []bool) (float64, float64) {
 			S--
 		}
 	}
-	V = float64(S) / math.Sqrt(float64(n))
-	P = math.Erfc(math.Abs(V) / math.Sqrt(2))
-	Q = math.Erfc(V/math.Sqrt(2)) / 2
+	V = float64(S) / math.Sqrt(float64(2*n))
+	P = math.Erfc(math.Abs(V))
+	Q = math.Erfc(V) / 2
 	return P, Q
 }

--- a/mono_bit_frequency_test.go
+++ b/mono_bit_frequency_test.go
@@ -12,3 +12,11 @@ func TestMonoBitFrequencyTestSample(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+func TestMonoBitFrequencyTestByteSample(t *testing.T) {
+	p, q := MonoBitFrequencyTestBytes([]byte{0xcc, 0x15, 0x6c, 0x4c, 0xe0, 0x02, 0x4d, 0x51, 0x13, 0xd6, 0x80, 0xd7, 0xcc, 0xe6, 0xd8, 0xb2})
+	fmt.Printf("n: %v, P-value: %.6f, Q-value: %.6f\n", len(sampleTestBits128), p, q)
+	if fmt.Sprintf("%.6f", p) != "0.215925" || fmt.Sprintf("%.6f", q) != "0.892038" {
+		t.FailNow()
+	}
+}

--- a/overlapping.go
+++ b/overlapping.go
@@ -70,15 +70,13 @@ func OverlappingTemplateMatchingProto(bits []bool, m int) (p1 float64, p2 float6
 
 	// 本来这里需要取bits后面预先插入bits[:m-1]，使得bits[m-1:]的长度依然是n。
 	// 现在改成不对bits切片做预处理，而是取位时对索引进行模操作。
-	// 两种实现各有利弊：原来的实现迭代取位时没啥计算，但是需要对较大的切片进行预处理（内存操作）；
-	// 而最新实现正好相反。
-
+	//
 	// Step 2
 	tmp := subsequencepattern(bits, m-1)
 
-	for i := 0; i < n; i++ {
+	for i := m - 1; i < n+m-1; i++ {
 		tmp <<= 1
-		if bits[(i+m-1)%n] {
+		if bits[i%n] { // i % n is used to avoid appending m-1 bits in the end
 			tmp++
 		}
 		patterns1[tmp&mask1]++

--- a/overlapping.go
+++ b/overlapping.go
@@ -68,6 +68,11 @@ func OverlappingTemplateMatchingProto(bits []bool, m int) (p1 float64, p2 float6
 	var mask2 int = (1 << (m - 1)) - 1
 	var mask3 int = (1 << (m - 2)) - 1
 
+	// 本来这里需要取bits后面预先插入bits[:m-1]，使得bits[m-1:]的长度依然是n。
+	// 现在改成不对bits切片做预处理，而是取位时对索引进行模操作。
+	// 两种实现各有利弊：原来的实现迭代取位时没啥计算，但是需要对较大的切片进行预处理（内存操作）；
+	// 而最新实现正好相反。
+
 	// Step 2
 	tmp := subsequencepattern(bits, m-1)
 

--- a/overlapping.go
+++ b/overlapping.go
@@ -68,18 +68,12 @@ func OverlappingTemplateMatchingProto(bits []bool, m int) (p1 float64, p2 float6
 	var mask2 int = (1 << (m - 1)) - 1
 	var mask3 int = (1 << (m - 2)) - 1
 
-	// Step 1, construct new bits
-	bits = append(bits, bits[:m-1]...)
-
 	// Step 2
-	var b bool
 	tmp := subsequencepattern(bits, m-1)
-	bits = bits[m-1:]
 
 	for i := 0; i < n; i++ {
 		tmp <<= 1
-		b, bits = bits[0], bits[1:]
-		if b {
+		if bits[(i+m-1)%n] {
 			tmp++
 		}
 		patterns1[tmp&mask1]++

--- a/poker.go
+++ b/poker.go
@@ -22,13 +22,15 @@ func PokerTest(bits []bool) (float64, float64) {
 }
 
 // PokerTestBytes 扑克检测
+// 这里直接对字节直接处理，避免字节切片到位切片的转换，同时提高效率。
+//
 // data: 检测序列
 // m: m长度，m=4,8
 func PokerTestBytes(data []byte, m int) (float64, float64) {
 	if len(data) == 0 {
 		panic("please provide valid test bits")
 	}
-	if m != 4 && m != 8 {
+	if m != 4 && m != 8 { // 如果m不是4也不是8，那么回退到位级别处理
 		return PokerProto(B2bitArr(data), m)
 	}
 	// 2^m

--- a/poker.go
+++ b/poker.go
@@ -29,7 +29,7 @@ func PokerTestBytes(data []byte, m int) (float64, float64) {
 		panic("please provide valid test bits")
 	}
 	if m != 4 && m != 8 {
-		panic("just support m=4 or m=8")
+		return PokerProto(B2bitArr(data), m)
 	}
 	// 2^m
 	_2m := 1 << m

--- a/poker.go
+++ b/poker.go
@@ -25,7 +25,41 @@ func PokerTest(bits []bool) (float64, float64) {
 // data: 检测序列
 // m: m长度，m=4,8
 func PokerTestBytes(data []byte, m int) (float64, float64) {
-	return PokerProto(B2bitArr(data), m)
+	if len(data) == 0 {
+		panic("please provide valid test bits")
+	}
+	if m != 4 && m != 8 {
+		panic("just support m=4 or m=8")
+	}
+	// 2^m
+	_2m := 1 << m
+
+	patterns := make([]int, _2m)
+	N := (len(data) * 8) / m
+	var V float64 = 0
+	var P float64 = 0
+
+	if m == 8 {
+		for i := 0; i < N; i++ {
+			patterns[data[i]]++
+		}
+	} else { // m = 4
+		for i := 0; i < len(data); i++ {
+			patterns[data[i] >> 4]++
+			patterns[data[i]&0x0f]++
+		}
+	}
+
+	for i := 0; i < _2m; i++ {
+		V += float64(patterns[i]) * float64(patterns[i])
+	}
+
+	V *= float64(_2m)
+	V /= float64(N)
+	V -= float64(N)
+
+	P = igamc(float64(_2m-1)/2, V/2)
+	return P, P
 }
 
 // PokerProto 扑克检测

--- a/poker_test.go
+++ b/poker_test.go
@@ -12,3 +12,27 @@ func TestPokerTestSample(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+func TestPokerTestM8Sample(t *testing.T) {
+	p, q := PokerProto(sampleTestBits128, 8)
+	fmt.Printf("n: %v, P-value: %f, Q-value: %f\n", len(sampleTestBits128), p, q)
+	if fmt.Sprintf("%.6f", p) != "0.221829" || fmt.Sprintf("%.6f", q) != "0.221829" {
+		t.FailNow()
+	}
+}
+
+func TestPokerTestByteSample(t *testing.T) {
+	p, q := PokerTestBytes([]byte{0xcc, 0x15, 0x6c, 0x4c, 0xe0, 0x02, 0x4d, 0x51, 0x13, 0xd6, 0x80, 0xd7, 0xcc, 0xe6, 0xd8, 0xb2}, 4)
+	fmt.Printf("n: %v, P-value: %f, Q-value: %f\n", len(sampleTestBits128), p, q)
+	if fmt.Sprintf("%.6f", p) != "0.213734" || fmt.Sprintf("%.6f", q) != "0.213734" {
+		t.FailNow()
+	}
+}
+
+func TestPokerTestByteM8Sample(t *testing.T) {
+	p, q := PokerTestBytes([]byte{0xcc, 0x15, 0x6c, 0x4c, 0xe0, 0x02, 0x4d, 0x51, 0x13, 0xd6, 0x80, 0xd7, 0xcc, 0xe6, 0xd8, 0xb2}, 8)
+	fmt.Printf("n: %v, P-value: %f, Q-value: %f\n", len(sampleTestBits128), p, q)
+	if fmt.Sprintf("%.6f", p) != "0.221829" || fmt.Sprintf("%.6f", q) != "0.221829" {
+		t.FailNow()
+	}
+}

--- a/runs.go
+++ b/runs.go
@@ -50,7 +50,7 @@ func RunsTest(bits []bool) (float64, float64) {
 	}
 	Pi /= float64(n)
 
-	// Step 3
+	// Step 3, 第四、五步的除math.Sqrt(2)，放到这里提前处理，减少math.Sqrt的调用。
 	V := (float64(V_obs) - 2.0*float64(n)*Pi*(1.0-Pi)) / (2.0 * math.Sqrt(float64(2*n)) * Pi * (1.0 - Pi))
 
 	// Step 4

--- a/runs.go
+++ b/runs.go
@@ -51,12 +51,12 @@ func RunsTest(bits []bool) (float64, float64) {
 	Pi /= float64(n)
 
 	// Step 3
-	V := (float64(V_obs) - 2.0*float64(n)*Pi*(1.0-Pi)) / (2.0 * math.Sqrt(float64(n)) * Pi * (1.0 - Pi))
+	V := (float64(V_obs) - 2.0*float64(n)*Pi*(1.0-Pi)) / (2.0 * math.Sqrt(float64(2*n)) * Pi * (1.0 - Pi))
 
 	// Step 4
-	P = math.Erfc(math.Abs(V) / math.Sqrt(2))
+	P = math.Erfc(math.Abs(V))
 
 	// Step 5
-	Q = math.Erfc(V / math.Sqrt(2)) / 2.0
+	Q = math.Erfc(V) / 2.0
 	return P, Q
 }

--- a/runs_distribution.go
+++ b/runs_distribution.go
@@ -47,10 +47,7 @@ func RunsDistributionTest(bits []bool) (float64, float64) {
 	var cur bool = bits[0]
 	cnt := 0
 
-	// 增加一终止位，避免特殊处理
-	bits = append(bits, !(bits[n-1]))
-
-	for i := 0; i <= n; i++ {
+	for i := 0; i < n; i++ {
 		if bits[i] == cur {
 			cnt++
 		} else {
@@ -65,6 +62,15 @@ func RunsDistributionTest(bits []bool) (float64, float64) {
 			cur = bits[i]
 			cnt = 1
 		}
+	}
+	// 特殊处理结尾
+	if cnt > k {
+		cnt = k
+	}
+	if cur {
+		b[cnt-1]++
+	} else {
+		g[cnt-1]++
 	}
 
 	// Step 3


### PR DESCRIPTION
- 对单比特频数检测、扑克检测（m=4, 8）可以直接对字节切片进行处理，无需先把字节数组转成位切片。没有修改tools/rddetector下的work_xxx，需要调整顺序，先处理单比特频数检测、扑克检测，再转换成位切片处理其它。
- 游程分布检测、重叠子序列检测、近似熵检测，去除了对位切片的append操作；近似熵检测方法使用了NIST的类似算法。
- 尽量减少重复计算。
- 增加了一个slow workflow，用于测试detect_test和detect_fast_test，平常如果嫌慢，可以disable掉它。